### PR TITLE
fix: remove hardcoded secrets from test file

### DIFF
--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -97,9 +97,9 @@ func TestInitializeApp(t *testing.T) {
 	}
 
 	cfg := &config.Config{
-		DatabaseURL:         "postgresql://***REMOVED***:leTwTKXWqO7Dvouz@***REMOVED***:5432/postgres?search_path=homepay",
-		ClerkSecretKey:     "sk_test_SHqpiFc0TyiGVznWFwq1da22o0bRTKOm2189gJTRBi",
-		ClerkWebhookSecret: "whsec_CrNyZwao5nPMn9umX85j2JIGbRLRrd1P",
+		DatabaseURL:         "postgresql://***REMOVED***:5432/test",
+		ClerkSecretKey:     "sk_test_placeholder",
+		ClerkWebhookSecret: "whsec_placeholder",
 		Port:              "0",
 	}
 


### PR DESCRIPTION
## Summary
- Remove hardcoded database URL, Clerk secret key, and webhook secret from test file
- Replace with placeholder values to prevent secret exposure in git history

## Why
The test file contained real credentials that were exposed in the codebase. This is a security risk.