### PR TITLE
fix(ci): resolve GitHub Actions validation errors

### DIFF
--- a/.github/workflows/continuous-docs.yml
+++ b/.github/workflows/continuous-docs.yml
@@ -2,7 +2,7 @@ name: 📚 Continuous Documentation
 
 on:
   pull_request:
-  branches-ignore:
+    branches-ignore:
       - main
     types: [opened, synchronize]
     paths:

--- a/.github/workflows/the-suggester-discussion-mode.yml
+++ b/.github/workflows/the-suggester-discussion-mode.yml
@@ -34,5 +34,5 @@ jobs:
     secrets:
       # Use GITHUB_TOKEN (automatically available, scoped to repo)
       # Only pass external secrets if absolutely required
-      GH_PAT: ${{ GITHUB_TOKEN }}
+      GH_PAT: ${{ secrets.GITHUB_TOKEN }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## Summary
- Fix token expression error in `the-suggester-discussion-mode.yml` (line 37): changed `${{ GITHUB_TOKEN }}` to `${{ secrets.GITHUB_TOKEN }}`
- Fix YAML syntax error in `continuous-docs.yml` (line 5): corrected indentation of `branches-ignore`

Fixes #9