### PR TITLE
feat(companies): include category_name in list API response

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2011,6 +2011,38 @@ const docTemplate = `{
                 }
             }
         },
+        "/health/ready": {
+            "get": {
+                "description": "Returns 200 if the service and database are ready. Used by GCP Cloud Run readiness probe.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Health check - readiness probe",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/installments": {
             "get": {
                 "security": [
@@ -2627,6 +2659,9 @@ const docTemplate = `{
                 "category_id": {
                     "type": "integer"
                 },
+                "category_name": {
+                    "type": "string"
+                },
                 "created_at": {
                     "type": "string"
                 },
@@ -3033,7 +3068,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "1.0",
+	Version:          "${VERSION}",
 	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{},

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,7 +4,7 @@
         "description": "Backend REST para gestión de finanzas personales HomePay. Todos los endpoints protegidos requieren un JWT de Clerk en el header Authorization.",
         "title": "HomePay API",
         "contact": {},
-        "version": "1.0"
+        "version": "${VERSION}"
     },
     "basePath": "/",
     "paths": {
@@ -2004,6 +2004,38 @@
                 }
             }
         },
+        "/health/ready": {
+            "get": {
+                "description": "Returns 200 if the service and database are ready. Used by GCP Cloud Run readiness probe.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "health"
+                ],
+                "summary": "Health check - readiness probe",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/installments": {
             "get": {
                 "security": [
@@ -2619,6 +2651,9 @@
                 },
                 "category_id": {
                     "type": "integer"
+                },
+                "category_name": {
+                    "type": "string"
                 },
                 "created_at": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -80,6 +80,8 @@ definitions:
         type: string
       category_id:
         type: integer
+      category_name:
+        type: string
       created_at:
         type: string
       deleted_at:
@@ -342,7 +344,7 @@ info:
   description: Backend REST para gestión de finanzas personales HomePay. Todos los
     endpoints protegidos requieren un JWT de Clerk en el header Authorization.
   title: HomePay API
-  version: "1.0"
+  version: ${VERSION}
 paths:
   /account-groups:
     get:
@@ -1636,6 +1638,28 @@ paths:
       summary: Editar gasto
       tags:
       - expenses
+  /health/ready:
+    get:
+      description: Returns 200 if the service and database are ready. Used by GCP
+        Cloud Run readiness probe.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "503":
+          description: Service Unavailable
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      summary: Health check - readiness probe
+      tags:
+      - health
   /installments:
     get:
       description: Retorna todos los planes activos del usuario con sus pagos individuales

--- a/internal/handlers/dashboard_test.go
+++ b/internal/handlers/dashboard_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/homepay/api/internal/middleware"
 	"github.com/homepay/api/internal/service"
@@ -51,14 +52,18 @@ func TestDashboardHandler_Get(t *testing.T) {
 	})
 
 	t.Run("success - default to current month/year", func(t *testing.T) {
+		now := time.Now()
+		currentMonth := int(now.Month())
+		currentYear := now.Year()
+
 		summary := &service.DashboardSummary{
-			Month:        4,
-			Year:         2026,
+			Month:        currentMonth,
+			Year:         currentYear,
 			TotalBilled:  150000,
 			TotalPaid:    100000,
 			TotalPending: 50000,
 		}
-		mockSvc.On("GetSummary", mock.Anything, "user_123", 4, 2026).Return(summary, nil)
+		mockSvc.On("GetSummary", mock.Anything, "user_123", currentMonth, currentYear).Return(summary, nil)
 
 		req := httptest.NewRequest("GET", "/dashboard", nil)
 		req = req.WithContext(context.WithValue(req.Context(), middleware.AuthUserIDKey, "user_123"))

--- a/internal/models/company.go
+++ b/internal/models/company.go
@@ -3,15 +3,16 @@ package models
 import "time"
 
 type Company struct {
-	ID         string     `json:"id"`
-	AuthUserID string     `json:"auth_user_id"`
-	CategoryID int        `json:"category_id"`
-	Name       string     `json:"name"`
-	Website    *string    `json:"website,omitempty"`
-	Phone      *string    `json:"phone,omitempty"`
-	IsActive   bool       `json:"is_active"`
-	CreatedAt  time.Time  `json:"created_at"`
-	DeletedAt  *time.Time `json:"deleted_at,omitempty"`
+	ID           string     `json:"id"`
+	AuthUserID   string     `json:"auth_user_id"`
+	CategoryID   int        `json:"category_id"`
+	CategoryName *string    `json:"category_name,omitempty"`
+	Name         string     `json:"name"`
+	Website      *string    `json:"website,omitempty"`
+	Phone        *string    `json:"phone,omitempty"`
+	IsActive     bool       `json:"is_active"`
+	CreatedAt    time.Time  `json:"created_at"`
+	DeletedAt    *time.Time `json:"deleted_at,omitempty"`
 }
 
 type CreateCompanyRequest struct {

--- a/internal/repository/company_repo.go
+++ b/internal/repository/company_repo.go
@@ -30,6 +30,10 @@ func scanCompany(row pgx.Row, c *models.Company) error {
 	return row.Scan(&c.ID, &c.AuthUserID, &c.CategoryID, &c.Name, &c.Website, &c.Phone, &c.IsActive, &c.CreatedAt, &c.DeletedAt)
 }
 
+func scanCompanyWithCategory(row pgx.Row, c *models.Company) error {
+	return row.Scan(&c.ID, &c.AuthUserID, &c.CategoryID, &c.CategoryName, &c.Name, &c.Website, &c.Phone, &c.IsActive, &c.CreatedAt, &c.DeletedAt)
+}
+
 func (r *companyRepo) Create(ctx context.Context, authUserID string, req *models.CreateCompanyRequest) (*models.Company, error) {
 	var c models.Company
 	err := scanCompany(r.db.QueryRow(ctx, `
@@ -70,10 +74,12 @@ func (r *companyRepo) GetAll(ctx context.Context, authUserID string, p models.Pa
 	}
 
 	rows, err := r.db.Query(ctx, `
-		SELECT `+companyCols+`
-		FROM homepay.companies
-		WHERE auth_user_id = $1 AND deleted_at IS NULL
-		ORDER BY created_at DESC
+		SELECT co.id, co.auth_user_id, co.category_id, c.name AS category_name,
+		       co.name, co.website, co.phone, co.is_active, co.created_at, co.deleted_at
+		FROM homepay.companies co
+		LEFT JOIN homepay.categories c ON c.id = co.category_id
+		WHERE co.auth_user_id = $1 AND co.deleted_at IS NULL
+		ORDER BY co.created_at DESC
 		LIMIT $2 OFFSET $3
 	`, authUserID, p.Limit, p.Offset())
 	if err != nil {
@@ -84,7 +90,7 @@ func (r *companyRepo) GetAll(ctx context.Context, authUserID string, p models.Pa
 	var companies []models.Company
 	for rows.Next() {
 		var c models.Company
-		if err := rows.Scan(&c.ID, &c.AuthUserID, &c.CategoryID, &c.Name, &c.Website, &c.Phone, &c.IsActive, &c.CreatedAt, &c.DeletedAt); err != nil {
+		if err := rows.Scan(&c.ID, &c.AuthUserID, &c.CategoryID, &c.CategoryName, &c.Name, &c.Website, &c.Phone, &c.IsActive, &c.CreatedAt, &c.DeletedAt); err != nil {
 			return nil, 0, err
 		}
 		companies = append(companies, c)


### PR DESCRIPTION
## Summary
- Add `category_name` field to Company model
- Modify `GetAll` SQL query with LEFT JOIN on `homepay.categories` to return category name
- Update scan logic to read the new `category_name` column
- Regenerate swagger docs

## Test plan
- [x] Code compiles
- [x] Repository tests pass (unit + integration)
- [x] Swagger docs regenerated

## Related Issue
Closes #11