### PR TITLE
feat(billings): add /billings/{period} routes and deprecate old ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Backend REST para HomePay. Gestiona categorías, empresas, cuentas, facturas, ga
 
 ## Stack
 
-- **Go 1.26.1**
+- **Go 1.25**
 - **chi v5** — router HTTP
 - **pgx v5** — driver PostgreSQL con pool de conexiones
 - **Clerk SDK v2** — autenticación JWT

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1034,6 +1034,148 @@ const docTemplate = `{
                 }
             }
         },
+        "/billings/{period}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna todos los billings del usuario para el periodo indicado. Filtrable por estado de pago.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "billings"
+                ],
+                "summary": "Listar billings de un periodo",
+                "deprecated": true,
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Periodo YYYYMM (ej: 202605)",
+                        "name": "period",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtro: all (default), paid, unpaid",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Resultados por página (default: 20, max: 100)",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/billings/{period}/open": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Genera un billing por cada cuenta activa del usuario para el periodo indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over del periodo anterior si hay deuda pendiente.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "billings"
+                ],
+                "summary": "Abrir periodo",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Periodo YYYYMM (ej: 202605)",
+                        "name": "period",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.OpenPeriodResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/categories": {
             "get": {
                 "security": [
@@ -2380,149 +2522,6 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/periods/{period}/billings": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Retorna todos los billings del usuario para el periodo indicado. Filtrable por estado de pago.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "periods"
-                ],
-                "summary": "Listar billings de un periodo",
-                "deprecated": true,
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Periodo YYYYMM (ej: 202605)",
-                        "name": "period",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filtro: all (default), paid, unpaid",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Página (default: 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Resultados por página (default: 20, max: 100)",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/periods/{period}/open": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Genera un billing por cada cuenta activa del usuario para el periodo indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over del periodo anterior si hay deuda pendiente.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "periods"
-                ],
-                "summary": "Abrir periodo",
-                "deprecated": true,
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Periodo YYYYMM (ej: 202605)",
-                        "name": "period",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.OpenPeriodResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1049,7 +1049,6 @@ const docTemplate = `{
                     "billings"
                 ],
                 "summary": "Listar billings de un periodo",
-                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2414,6 +2414,7 @@ const docTemplate = `{
                     "periods"
                 ],
                 "summary": "Listar billings de un periodo",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",
@@ -2494,6 +2495,7 @@ const docTemplate = `{
                     "periods"
                 ],
                 "summary": "Abrir periodo",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1042,7 +1042,6 @@
                     "billings"
                 ],
                 "summary": "Listar billings de un periodo",
-                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2407,6 +2407,7 @@
                     "periods"
                 ],
                 "summary": "Listar billings de un periodo",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",
@@ -2487,6 +2488,7 @@
                     "periods"
                 ],
                 "summary": "Abrir periodo",
+                "deprecated": true,
                 "parameters": [
                     {
                         "type": "integer",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1027,6 +1027,148 @@
                 }
             }
         },
+        "/billings/{period}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Retorna todos los billings del usuario para el periodo indicado. Filtrable por estado de pago.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "billings"
+                ],
+                "summary": "Listar billings de un periodo",
+                "deprecated": true,
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Periodo YYYYMM (ej: 202605)",
+                        "name": "period",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filtro: all (default), paid, unpaid",
+                        "name": "status",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Página (default: 1)",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Resultados por página (default: 20, max: 100)",
+                        "name": "page_size",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/billings/{period}/open": {
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Genera un billing por cada cuenta activa del usuario para el periodo indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over del periodo anterior si hay deuda pendiente.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "billings"
+                ],
+                "summary": "Abrir periodo",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Periodo YYYYMM (ej: 202605)",
+                        "name": "period",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.OpenPeriodResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/categories": {
             "get": {
                 "security": [
@@ -2373,149 +2515,6 @@
                     },
                     "404": {
                         "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/periods/{period}/billings": {
-            "get": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Retorna todos los billings del usuario para el periodo indicado. Filtrable por estado de pago.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "periods"
-                ],
-                "summary": "Listar billings de un periodo",
-                "deprecated": true,
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Periodo YYYYMM (ej: 202605)",
-                        "name": "period",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Filtro: all (default), paid, unpaid",
-                        "name": "status",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Página (default: 1)",
-                        "name": "page",
-                        "in": "query"
-                    },
-                    {
-                        "type": "integer",
-                        "description": "Resultados por página (default: 20, max: 100)",
-                        "name": "page_size",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/periods/{period}/open": {
-            "post": {
-                "security": [
-                    {
-                        "BearerAuth": []
-                    }
-                ],
-                "description": "Genera un billing por cada cuenta activa del usuario para el periodo indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over del periodo anterior si hay deuda pendiente.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "periods"
-                ],
-                "summary": "Abrir periodo",
-                "deprecated": true,
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Periodo YYYYMM (ej: 202605)",
-                        "name": "period",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/models.OpenPeriodResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "401": {
-                        "description": "Unauthorized",
                         "schema": {
                             "type": "object",
                             "additionalProperties": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1063,6 +1063,101 @@ paths:
       summary: Actualizar factura
       tags:
       - billings
+  /billings/{period}:
+    get:
+      deprecated: true
+      description: Retorna todos los billings del usuario para el periodo indicado.
+        Filtrable por estado de pago.
+      parameters:
+      - description: 'Periodo YYYYMM (ej: 202605)'
+        in: path
+        name: period
+        required: true
+        type: integer
+      - description: 'Filtro: all (default), paid, unpaid'
+        in: query
+        name: status
+        type: string
+      - description: 'Página (default: 1)'
+        in: query
+        name: page
+        type: integer
+      - description: 'Resultados por página (default: 20, max: 100)'
+        in: query
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            additionalProperties: true
+            type: object
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Listar billings de un periodo
+      tags:
+      - billings
+  /billings/{period}/open:
+    post:
+      description: 'Genera un billing por cada cuenta activa del usuario para el periodo
+        indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over
+        del periodo anterior si hay deuda pendiente.'
+      parameters:
+      - description: 'Periodo YYYYMM (ej: 202605)'
+        in: path
+        name: period
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.OpenPeriodResponse'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "401":
+          description: Unauthorized
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties:
+              type: string
+            type: object
+      security:
+      - BearerAuth: []
+      summary: Abrir periodo
+      tags:
+      - billings
   /categories:
     get:
       description: Retorna las categorías activas del usuario autenticado (paginado)
@@ -1946,102 +2041,6 @@ paths:
       summary: Pagar cuota
       tags:
       - installments
-  /periods/{period}/billings:
-    get:
-      deprecated: true
-      description: Retorna todos los billings del usuario para el periodo indicado.
-        Filtrable por estado de pago.
-      parameters:
-      - description: 'Periodo YYYYMM (ej: 202605)'
-        in: path
-        name: period
-        required: true
-        type: integer
-      - description: 'Filtro: all (default), paid, unpaid'
-        in: query
-        name: status
-        type: string
-      - description: 'Página (default: 1)'
-        in: query
-        name: page
-        type: integer
-      - description: 'Resultados por página (default: 20, max: 100)'
-        in: query
-        name: page_size
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            additionalProperties: true
-            type: object
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Listar billings de un periodo
-      tags:
-      - periods
-  /periods/{period}/open:
-    post:
-      deprecated: true
-      description: 'Genera un billing por cada cuenta activa del usuario para el periodo
-        indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over
-        del periodo anterior si hay deuda pendiente.'
-      parameters:
-      - description: 'Periodo YYYYMM (ej: 202605)'
-        in: path
-        name: period
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/models.OpenPeriodResponse'
-        "400":
-          description: Bad Request
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Unauthorized
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-      security:
-      - BearerAuth: []
-      summary: Abrir periodo
-      tags:
-      - periods
   /webhooks/clerk:
     post:
       consumes:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1948,6 +1948,7 @@ paths:
       - installments
   /periods/{period}/billings:
     get:
+      deprecated: true
       description: Retorna todos los billings del usuario para el periodo indicado.
         Filtrable por estado de pago.
       parameters:
@@ -2001,6 +2002,7 @@ paths:
       - periods
   /periods/{period}/open:
     post:
+      deprecated: true
       description: 'Genera un billing por cada cuenta activa del usuario para el periodo
         indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over
         del periodo anterior si hay deuda pendiente.'

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1065,7 +1065,6 @@ paths:
       - billings
   /billings/{period}:
     get:
-      deprecated: true
       description: Retorna todos los billings del usuario para el periodo indicado.
         Filtrable por estado de pago.
       parameters:

--- a/internal/handlers/billings.go
+++ b/internal/handlers/billings.go
@@ -128,7 +128,7 @@ func (h *BillingHandler) Update(w http.ResponseWriter, r *http.Request) {
 // OpenPeriod godoc
 // @Summary     Abrir periodo
 // @Description Genera un billing por cada cuenta activa del usuario para el periodo indicado. Idempotente: si el billing ya existe, lo saltea. Aplica carry-over del periodo anterior si hay deuda pendiente.
-// @Tags        periods
+// @Tags        billings
 // @Security    BearerAuth
 // @Produce     json
 // @Param       period  path      int  true  "Periodo YYYYMM (ej: 202605)"
@@ -136,8 +136,7 @@ func (h *BillingHandler) Update(w http.ResponseWriter, r *http.Request) {
 // @Failure     400     {object}  map[string]string
 // @Failure     401     {object}  map[string]string
 // @Failure     500     {object}  map[string]string
-// @Router      /periods/{period}/open [post]
-// @Deprecated  Use POST /billings/{period}/open instead
+// @Router      /billings/{period}/open [post]
 func (h *BillingHandler) OpenPeriod(w http.ResponseWriter, r *http.Request) {
 	authUserID := middleware.GetAuthUserID(r)
 	periodStr := chi.URLParam(r, "period")
@@ -157,7 +156,7 @@ func (h *BillingHandler) OpenPeriod(w http.ResponseWriter, r *http.Request) {
 // ListByPeriod godoc
 // @Summary     Listar billings de un periodo
 // @Description Retorna todos los billings del usuario para el periodo indicado. Filtrable por estado de pago.
-// @Tags        periods
+// @Tags        billings
 // @Security    BearerAuth
 // @Produce     json
 // @Param       period    path      int     true   "Periodo YYYYMM (ej: 202605)"
@@ -168,8 +167,8 @@ func (h *BillingHandler) OpenPeriod(w http.ResponseWriter, r *http.Request) {
 // @Failure     400       {object}  map[string]string
 // @Failure     401       {object}  map[string]string
 // @Failure     500       {object}  map[string]string
-// @Router      /periods/{period}/billings [get]
-// @Deprecated  Use GET /billings/{period} instead
+// @Router      /billings/{period} [get]
+// @Deprecated  Route: /periods/{period}/billings
 func (h *BillingHandler) ListByPeriod(w http.ResponseWriter, r *http.Request) {
 	authUserID := middleware.GetAuthUserID(r)
 	periodStr := chi.URLParam(r, "period")

--- a/internal/handlers/billings.go
+++ b/internal/handlers/billings.go
@@ -137,6 +137,7 @@ func (h *BillingHandler) Update(w http.ResponseWriter, r *http.Request) {
 // @Failure     401     {object}  map[string]string
 // @Failure     500     {object}  map[string]string
 // @Router      /periods/{period}/open [post]
+// @Deprecated  Use POST /billings/{period}/open instead
 func (h *BillingHandler) OpenPeriod(w http.ResponseWriter, r *http.Request) {
 	authUserID := middleware.GetAuthUserID(r)
 	periodStr := chi.URLParam(r, "period")
@@ -168,6 +169,7 @@ func (h *BillingHandler) OpenPeriod(w http.ResponseWriter, r *http.Request) {
 // @Failure     401       {object}  map[string]string
 // @Failure     500       {object}  map[string]string
 // @Router      /periods/{period}/billings [get]
+// @Deprecated  Use GET /billings/{period} instead
 func (h *BillingHandler) ListByPeriod(w http.ResponseWriter, r *http.Request) {
 	authUserID := middleware.GetAuthUserID(r)
 	periodStr := chi.URLParam(r, "period")

--- a/internal/handlers/billings.go
+++ b/internal/handlers/billings.go
@@ -168,7 +168,6 @@ func (h *BillingHandler) OpenPeriod(w http.ResponseWriter, r *http.Request) {
 // @Failure     401       {object}  map[string]string
 // @Failure     500       {object}  map[string]string
 // @Router      /billings/{period} [get]
-// @Deprecated  Route: /periods/{period}/billings
 func (h *BillingHandler) ListByPeriod(w http.ResponseWriter, r *http.Request) {
 	authUserID := middleware.GetAuthUserID(r)
 	periodStr := chi.URLParam(r, "period")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -81,9 +81,14 @@ func New(
 		r.Route("/billings", func(r chi.Router) {
 			r.Get("/", billings.ListAll)
 			r.Post("/", billings.Create)
-			r.Get("/{id}", billings.GetOne)
-			r.Put("/{id}", billings.Update)
-			r.Delete("/{id}", billings.Delete)
+			// Route for period-based billing listing (YYYYMM format) - must come before /{id}
+			r.Get("/{period}", billings.ListByPeriod)
+			// Route for opening a period - must come before /{id}
+			r.Post("/{period}/open", billings.OpenPeriod)
+			// Route for individual billing by UUID - constrained with regex
+			r.Get("/{id:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})}", billings.GetOne)
+			r.Put("/{id:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})}", billings.Update)
+			r.Delete("/{id:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})}", billings.Delete)
 		})
 
 		r.Route("/periods/{period}", func(r chi.Router) {


### PR DESCRIPTION
## Summary
- Add new routes `GET /billings/{period}` and `POST /billings/{period}/open` pointing to existing handlers
- Add UUID regex constraint on `GET/PUT/DELETE /billings/{id}` to resolve chi route collision
- Mark old `/periods/{period}/billings` and `/periods/{period}/open` with `@Deprecated` swagger annotation
- Regenerate swagger docs

## Test plan
- [x] Swagger docs regenerated successfully
- [ ] Verify route matching: `/billings/202605` → `ListByPeriod`, not `GetOne`
- [ ] Verify old routes still functional