### PR TITLE
fix: inject version from VERSION file into swagger docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ run:
 	go run -ldflags "$(LDFLAGS)" ./cmd/api
 
 swag:
+	@sed 's/\$${VERSION}/$(VERSION)/g' cmd/api/main.go > cmd/api/main.go.tmp && \
+	mv cmd/api/main.go.tmp cmd/api/main.go
 	go run github.com/swaggo/swag/cmd/swag@latest init -g cmd/api/main.go --output docs
 
 release: swag build

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,5 +1,5 @@
 // @title           HomePay API
-// @version         ${VERSION}
+// @version         1.0.1
 // @description     Backend REST para gestión de finanzas personales HomePay. Todos los endpoints protegidos requieren un JWT de Clerk en el header Authorization.
 // @BasePath        /
 // @securityDefinitions.apikey BearerAuth

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3181,7 +3181,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "${VERSION}",
+	Version:          "1.0.1",
 	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{},

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4,7 +4,7 @@
         "description": "Backend REST para gestión de finanzas personales HomePay. Todos los endpoints protegidos requieren un JWT de Clerk en el header Authorization.",
         "title": "HomePay API",
         "contact": {},
-        "version": "${VERSION}"
+        "version": "1.0.1"
     },
     "basePath": "/",
     "paths": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -401,7 +401,7 @@ info:
   description: Backend REST para gestión de finanzas personales HomePay. Todos los
     endpoints protegidos requieren un JWT de Clerk en el header Authorization.
   title: HomePay API
-  version: ${VERSION}
+  version: 1.0.1
 paths:
   /account-groups:
     get:


### PR DESCRIPTION
## Summary
- Issue #25
- Modificado target `swag` del Makefile para injectar la versión real desde el archivo `VERSION` antes de correr `swag init`
- Regenerados los archivos de swagger con la versión correcta (`1.0.1`)

## Changes
- `Makefile`: sed replace de `${VERSION}` con el valor real antes de swag
- `cmd/api/main.go`, `docs/`: regenerados con la versión correctainjectada

## Test plan
- [x] `make swag` genera docs con versión correcta (`1.0.1`)