### PR TITLE
chore(config): run app on port 6011

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 DATABASE_URL=postgres://user:password@host:5432/db?search_path=homepay
 CLERK_SECRET_KEY=sk_test_xxxxxxxxxxxxxxxxxxxx
 CLERK_WEBHOOK_SECRET=whsec_xxxxxxxxxxxxxxxxxxxx
-PORT=8080
+PORT=6011
 
 # TLS (optional — for local HTTPS in development)
 # TLS_CERT_FILE=/path/to/cert.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ FROM alpine:3.20
 RUN addgroup -g 1000 appgroup && adduser -u 1000 -G appgroup -D appuser
 WORKDIR /app
 COPY --from=builder /app/server .
-EXPOSE 8080
+EXPOSE 6011
 USER appuser
 CMD ["./server"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Crea un archivo `.env` en la raíz con las siguientes variables:
 | `DATABASE_URL` | Connection string de Supabase con `search_path=homepay` |
 | `CLERK_SECRET_KEY` | Clave secreta de Clerk para validar JWT |
 | `CLERK_WEBHOOK_SECRET` | Secreto de firma de webhooks de Clerk (`whsec_...`) |
-| `PORT` | Puerto del servidor (default: `8080`) |
+| `PORT` | Puerto del servidor (default: `6011`) |
 
 ## Ejecutar en desarrollo
 
@@ -36,7 +36,7 @@ Crea un archivo `.env` en la raíz con las siguientes variables:
 go run ./cmd/api/main.go
 ```
 
-El servidor arranca en `http://localhost:8080`.
+El servidor arranca en `http://localhost:6011`.
 
 ## Ejecutar en Docker
 
@@ -44,7 +44,7 @@ El servidor arranca en `http://localhost:8080`.
 docker compose up --build
 ```
 
-La app queda expuesta en `http://localhost:8082`.
+La app queda expuesta en `http://localhost:6011`.
 
 ## Compilar binario
 
@@ -177,7 +177,7 @@ Todos los deletes son **soft delete** (`deleted_at = NOW()`). Las categorías so
 | `DATABASE_URL` | Connection string de Supabase con `search_path=homepay` |
 | `CLERK_SECRET_KEY` | Clave secreta de Clerk para validar JWT |
 | `CLERK_WEBHOOK_SECRET` | Secreto de firma de webhooks de Clerk (`whsec_...`) |
-| `PORT` | Puerto del servidor (default: `8080`) |
+| `PORT` | Puerto del servidor (default: `6011`) |
 
 ### Health check
 

--- a/agents.md
+++ b/agents.md
@@ -100,7 +100,7 @@ users (Clerk)
 | `DATABASE_URL` | Connection string Supabase con `?search_path=homepay` |
 | `CLERK_SECRET_KEY` | Clave secreta Clerk para validar JWT |
 | `CLERK_WEBHOOK_SECRET` | Secreto de firma de webhooks (`whsec_...`) |
-| `PORT` | Puerto HTTP (default `8080`) |
+| `PORT` | Puerto HTTP (default `6011`) |
 
 ## Comandos frecuentes
 
@@ -108,7 +108,7 @@ users (Clerk)
 # Desarrollo
 go run ./cmd/api/main.go
 
-# Docker local (puerto 8082)
+# Docker local (puerto 6011)
 docker compose up --build
 
 # Regenerar Swagger

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -58,13 +58,13 @@ func TestConfigValidation(t *testing.T) {
 			DatabaseURL:         "",
 			ClerkSecretKey:     "",
 			ClerkWebhookSecret: "",
-			Port:              "8080",
+			Port:              "6011",
 		}
 		if cfg == nil {
 			t.Fatal("config should not be nil")
 		}
-		if cfg.Port != "8080" {
-			t.Errorf("expected port 8080, got %s", cfg.Port)
+		if cfg.Port != "6011" {
+			t.Errorf("expected port 6011, got %s", cfg.Port)
 		}
 	})
 }
@@ -73,7 +73,7 @@ func TestConfigValidation(t *testing.T) {
 func TestAppStructure(t *testing.T) {
 	t.Run("App struct can be created", func(t *testing.T) {
 		app := &App{
-			Config:  &config.Config{Port: "8080"},
+			Config:  &config.Config{Port: "6011"},
 			DB:      &closer{},
 			Router:  http.DefaultServeMux,
 		}
@@ -136,11 +136,11 @@ func (m *mockDB) Ping(ctx context.Context) error {
 // TestGetServerConfig tests getServerConfig function
 func TestGetServerConfig(t *testing.T) {
 	t.Run("default port", func(t *testing.T) {
-		cfg := &config.Config{Port: "8080"}
+		cfg := &config.Config{Port: "6011"}
 		sc := getServerConfig(cfg)
 
-		if sc.Addr != ":8080" {
-			t.Errorf("expected :8080, got %s", sc.Addr)
+		if sc.Addr != ":6011" {
+			t.Errorf("expected :6011, got %s", sc.Addr)
 		}
 	})
 
@@ -216,7 +216,7 @@ func TestInitializeAppWithMockDB(t *testing.T) {
 		DatabaseURL:     os.Getenv("DATABASE_URL"),
 		ClerkSecretKey:  os.Getenv("CLERK_SECRET_KEY"),
 		ClerkWebhookSecret: os.Getenv("CLERK_WEBHOOK_SECRET"),
-		Port:            "8080",
+		Port:            "6011",
 	}
 
 	_, err := InitializeApp(cfg)
@@ -231,11 +231,11 @@ func TestInitializeAppWithMockDB(t *testing.T) {
 func TestServerConfigStruct(t *testing.T) {
 	t.Run("create ServerConfig", func(t *testing.T) {
 		sc := ServerConfig{
-			Addr: ":8080",
+			Addr: ":6011",
 		}
 
-		if sc.Addr != ":8080" {
-			t.Errorf("expected :8080, got %s", sc.Addr)
+		if sc.Addr != ":6011" {
+			t.Errorf("expected :6011, got %s", sc.Addr)
 		}
 	})
 }
@@ -305,7 +305,7 @@ func TestMainFlow(t *testing.T) {
 			DatabaseURL:     os.Getenv("DATABASE_URL"),
 			ClerkSecretKey:  os.Getenv("CLERK_SECRET_KEY"),
 			ClerkWebhookSecret: os.Getenv("CLERK_WEBHOOK_SECRET"),
-			Port:            "8080",
+			Port:            "6011",
 		}
 
 		_, err := InitializeApp(cfg)
@@ -316,7 +316,7 @@ func TestMainFlow(t *testing.T) {
 
 	t.Run("initialize with missing config", func(t *testing.T) {
 		cfg := &config.Config{
-			Port: "8080",
+			Port: "6011",
 		}
 
 		_, err := InitializeApp(cfg)
@@ -336,7 +336,7 @@ func TestAppIntegration(t *testing.T) {
 		DatabaseURL:     os.Getenv("DATABASE_URL"),
 		ClerkSecretKey:  os.Getenv("CLERK_SECRET_KEY"),
 		ClerkWebhookSecret: os.Getenv("CLERK_WEBHOOK_SECRET"),
-		Port:            "8080",
+		Port:            "6011",
 	}
 
 	app, err := InitializeApp(cfg)
@@ -362,7 +362,7 @@ func TestServerConfigAddr(t *testing.T) {
 		port     string
 		expected string
 	}{
-		{"8080", ":8080"},
+		{"6011", ":6011"},
 		{"3000", ":3000"},
 		{"443", ":443"},
 		{"0", ":0"},
@@ -439,7 +439,7 @@ func TestSetupMux(t *testing.T) {
 // TestMainWithMockServer tests the server setup flow
 func TestMainWithMockServer(t *testing.T) {
 	app = &App{
-		Config: &config.Config{Port: "8080"},
+		Config: &config.Config{Port: "6011"},
 		DB:     &mockDB{pingErr: nil},
 		Router: http.NewServeMux(),
 	}
@@ -500,7 +500,7 @@ func TestInitializeAppWrapper(t *testing.T) {
 		DatabaseURL:     os.Getenv("DATABASE_URL"),
 		ClerkSecretKey:  os.Getenv("CLERK_SECRET_KEY"),
 		ClerkWebhookSecret: os.Getenv("CLERK_WEBHOOK_SECRET"),
-		Port:            "8080",
+		Port:            "6011",
 	}
 
 	_, err := initializeApp(cfg)
@@ -512,9 +512,9 @@ func TestInitializeAppWrapper(t *testing.T) {
 // TestStartServer tests startServer function
 func TestStartServer(t *testing.T) {
 	t.Run("verify server config", func(t *testing.T) {
-		cfg := ServerConfig{Addr: ":8080"}
+		cfg := ServerConfig{Addr: ":6011"}
 
-		if cfg.Addr != ":8080" {
+		if cfg.Addr != ":6011" {
 			t.Error("config incorrect")
 		}
 	})
@@ -524,8 +524,8 @@ func TestStartServer(t *testing.T) {
 			name string
 			addr string
 		}{
-			{"localhost", "localhost:8080"},
-			{"port only", ":8080"},
+			{"localhost", "localhost:6011"},
+			{"port only", ":6011"},
 			{"empty", ""},
 		}
 
@@ -550,7 +550,7 @@ func TestLoadConfigEnv(t *testing.T) {
 		t.Setenv("DATABASE_URL", "localhost:5432/test")
 		t.Setenv("CLERK_SECRET_KEY", "sk_test_placeholder")
 		t.Setenv("CLERK_WEBHOOK_SECRET", "whsec_placeholder")
-		t.Setenv("PORT", "8080")
+		t.Setenv("PORT", "6011")
 
 		cfg, err := loadConfig()
 		if err != nil {
@@ -627,12 +627,12 @@ func TestConfigCompleteFlow(t *testing.T) {
 
 // TestServerConfigFlow tests full server setup flow
 func TestServerConfigFlow(t *testing.T) {
-	cfg := &config.Config{Port: "8080"}
+	cfg := &config.Config{Port: "6011"}
 	serverCfg := getServerConfig(cfg)
 
 	// Verify server config
-	if serverCfg.Addr != ":8080" {
-		t.Errorf("expected :8080, got %s", serverCfg.Addr)
+	if serverCfg.Addr != ":6011" {
+		t.Errorf("expected :6011, got %s", serverCfg.Addr)
 	}
 
 	// Setup mux
@@ -668,7 +668,7 @@ func TestMainParts(t *testing.T) {
 	})
 
 	t.Run("getServerConfig with various ports", func(t *testing.T) {
-		ports := []string{"80", "443", "9000", "8080"}
+		ports := []string{"80", "443", "9000", "6011"}
 		for _, port := range ports {
 			cfg := &config.Config{Port: port}
 			sc := getServerConfig(cfg)
@@ -690,7 +690,7 @@ func TestMainFlowCoverage(t *testing.T) {
 	os.Setenv("DATABASE_URL", "localhost:5432/test")
 	os.Setenv("CLERK_SECRET_KEY", "sk_test_placeholder")
 	os.Setenv("CLERK_WEBHOOK_SECRET", "whsec_placeholder")
-	os.Setenv("PORT", "8080")
+	os.Setenv("PORT", "6011")
 	defer func() {
 		os.Unsetenv("DATABASE_URL")
 		os.Unsetenv("CLERK_SECRET_KEY")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   api:
     build: .
     ports:
-      - "8082:8080"
+      - "6011:6011"
     env_file:
       - .env
 

--- a/docs/homepay-prd-etapa2-backend.md
+++ b/docs/homepay-prd-etapa2-backend.md
@@ -22,7 +22,7 @@ Este documento describe el API backend de HomePay. Debe leerse junto al PRD Etap
 DATABASE_URL        — connection string de Supabase con search_path=homepay
 CLERK_SECRET_KEY    — clave secreta de Clerk para validar JWT
 CLERK_WEBHOOK_SECRET — secreto para verificar firma de webhooks de Clerk
-PORT                — default 8080
+PORT                — default 6011
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -34,7 +34,7 @@ func Load() (*Config, error) {
 		return nil, fmt.Errorf("CLERK_WEBHOOK_SECRET is required")
 	}
 	if cfg.Port == "" {
-		cfg.Port = "8080"
+		cfg.Port = "6011"
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -160,7 +160,7 @@ func TestLoad_DefaultPort(t *testing.T) {
 		t.Fatalf("Load() error = %v", err)
 	}
 
-	if cfg.Port != "8080" {
-		t.Errorf("Port = %v, want default 8080", cfg.Port)
+	if cfg.Port != "6011" {
+		t.Errorf("Port = %v, want default 6011", cfg.Port)
 	}
 }


### PR DESCRIPTION
Closes #29

## PR Type
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary
- Updates the default API port to `6011`.
- Aligns Docker, Compose, env examples, docs, and tests with port `6011`.
- Confirms the app runs locally in Docker Desktop at `http://localhost:6011`.

## Changes
| File | Change |
|------|--------|
| `internal/config/config.go` | Changes fallback `PORT` default from `8080` to `6011`. |
| `Dockerfile` | Exposes port `6011`. |
| `docker-compose.yml` | Maps `6011:6011`. |
| `.env.example` | Documents `PORT=6011`. |
| `README.md`, `agents.md`, `docs/homepay-prd-etapa2-backend.md` | Updates documented local/Docker port references. |
| `cmd/api/main_test.go`, `internal/config/config_test.go` | Updates test expectations to port `6011`. |

## Test Plan
- [x] `go test ./internal/config ./cmd/api`
- [x] `docker compose config`
- [x] Fresh diff review passed
- [x] Ran via Docker Desktop and verified `http://localhost:6011` responds

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No shell scripts modified
- [x] Docs/config updated for behavior change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers