### PR TITLE
fix(billings): remove unused account id from billing routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ docker compose up --build
 
 La app queda expuesta en `http://localhost:6011`.
 
+### Republicar en Docker Desktop
+
+Para reconstruir la imagen y dejar la API corriendo en segundo plano:
+
+```bash
+docker compose up --build -d
+```
+
+Verificación rápida:
+
+```bash
+docker compose ps
+curl -L http://localhost:6011/docs/
+```
+
+Si el puerto `6011` ya está ocupado por una ejecución local, detené ese proceso y volvé a ejecutar el comando de republicación.
+
 ## Compilar binario
 
 ```bash

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -112,6 +112,13 @@ func InitializeApp(cfg *config.Config) (*App, error) {
 // @Failure     503  {object}  map[string]string
 // @Router      /health/ready [get]
 func healthReady(w http.ResponseWriter, r *http.Request) {
+	if app == nil || app.DB == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		json.NewEncoder(w).Encode(map[string]string{"error": "application unavailable"})
+		return
+	}
+
 	if err := app.DB.Ping(r.Context()); err != nil {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -132,7 +139,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	app, err := initializeApp(cfg)
+	app, err = initializeApp(cfg)
 	if err != nil {
 		slog.Error("app initialization error", "error", err)
 		os.Exit(1)

--- a/cmd/api/main_test.go
+++ b/cmd/api/main_test.go
@@ -156,6 +156,21 @@ func TestGetServerConfig(t *testing.T) {
 
 // TestHealthReady tests healthReady handler
 func TestHealthReady(t *testing.T) {
+	t.Run("application unavailable", func(t *testing.T) {
+		previousApp := app
+		app = nil
+		defer func() { app = previousApp }()
+
+		w := httptest.NewRecorder()
+		r, _ := http.NewRequest("GET", "/health/ready", nil)
+
+		healthReady(w, r)
+
+		if w.Code != http.StatusServiceUnavailable {
+			t.Errorf("expected status 503, got %d", w.Code)
+		}
+	})
+
 	t.Run("database available", func(t *testing.T) {
 		app = &App{
 			DB: &mockDB{pingErr: nil},

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -912,13 +912,6 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Account ID",
-                        "name": "accountID",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
                         "description": "Billing ID",
                         "name": "id",
                         "in": "path",

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -850,13 +850,6 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Account ID",
-                        "name": "accountID",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
                         "description": "Billing ID",
                         "name": "id",
                         "in": "path",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -843,13 +843,6 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Account ID",
-                        "name": "accountID",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
                         "description": "Billing ID",
                         "name": "id",
                         "in": "path",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -905,13 +905,6 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "Account ID",
-                        "name": "accountID",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
                         "description": "Billing ID",
                         "name": "id",
                         "in": "path",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -969,11 +969,6 @@ paths:
     get:
       description: Retorna una factura por ID
       parameters:
-      - description: Account ID
-        in: path
-        name: accountID
-        required: true
-        type: string
       - description: Billing ID
         in: path
         name: id

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1010,11 +1010,6 @@ paths:
       description: Actualiza monto pagado. Si amount_paid >= amount_billed se marca
         automáticamente como pagada.
       parameters:
-      - description: Account ID
-        in: path
-        name: accountID
-        required: true
-        type: string
       - description: Billing ID
         in: path
         name: id

--- a/internal/handlers/billings.go
+++ b/internal/handlers/billings.go
@@ -96,7 +96,6 @@ func (h *BillingHandler) Create(w http.ResponseWriter, r *http.Request) {
 // @Security    BearerAuth
 // @Accept      json
 // @Produce     json
-// @Param       accountID  path      string                      true  "Account ID"
 // @Param       id         path      string                      true  "Billing ID"
 // @Param       body       body      models.UpdateBillingRequest  true  "Campos a actualizar"
 // @Success     200        {object}  map[string]models.AccountBilling

--- a/internal/handlers/billings.go
+++ b/internal/handlers/billings.go
@@ -24,12 +24,11 @@ func NewBillingHandler(svc service.BillingService) *BillingHandler {
 // @Tags        billings
 // @Security    BearerAuth
 // @Produce     json
-// @Param       accountID  path      string  true  "Account ID"
-// @Param       id         path      string  true  "Billing ID"
-// @Success     200        {object}  models.AccountBilling
-// @Failure     401        {object}  map[string]string
-// @Failure     404        {object}  map[string]string
-// @Failure     500        {object}  map[string]string
+// @Param       id   path      string  true  "Billing ID"
+// @Success     200  {object}  models.AccountBilling
+// @Failure     401  {object}  map[string]string
+// @Failure     404  {object}  map[string]string
+// @Failure     500  {object}  map[string]string
 // @Router      /billings/{id} [get]
 func (h *BillingHandler) GetOne(w http.ResponseWriter, r *http.Request) {
 	authUserID := middleware.GetAuthUserID(r)


### PR DESCRIPTION
## Summary
- Remove the unused accountID path parameter from the GET /billings/{id} Swagger annotation.
- Remove the same unused accountID path parameter from the PUT /billings/{id} Swagger annotation.
- Regenerate Swagger docs so individual billing lookup/update only document the billing id.
- Document the Docker Desktop republication/rebuild path in README.
- Guard /health/ready when the application is unavailable and keep Docker readiness verification green.

Closes #31

## Test plan
- [x] go run github.com/swaggo/swag/cmd/swag@latest init -g cmd/api/main.go --output docs
- [x] go test ./internal/handlers ./docs
- [x] go test ./internal/service
- [x] go test ./internal/handlers ./internal/router
- [x] go build -o /tmp/api_home_pay_api ./cmd/api
- [x] docker compose up --build -d
- [x] curl -L http://localhost:6011/docs/
- [x] curl http://localhost:6011/health/ready
- [x] go test ./cmd/api -run 'TestHealthReady|TestSetupMux' -count=1
- [x] go test ./internal/repository -run TestAccountRepo_Update_Integration -count=1 -timeout=30s -v
- [x] go test ./... -short -count=1 -timeout=30s
- [ ] go test ./... -count=1 -timeout=30s — times out in repository integration/testcontainers cleanup; fresh review classified it as environmental/pre-existing for this change.
- [x] Fresh reviews: PASS