### PR TITLE
feat(billings): include account name in detail response

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2619,6 +2619,9 @@ const docTemplate = `{
                 "account_id": {
                     "type": "string"
                 },
+                "account_name": {
+                    "type": "string"
+                },
                 "amount_billed": {
                     "type": "number"
                 },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2612,6 +2612,9 @@
                 "account_id": {
                     "type": "string"
                 },
+                "account_name": {
+                    "type": "string"
+                },
                 "amount_billed": {
                     "type": "number"
                 },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -29,6 +29,8 @@ definitions:
     properties:
       account_id:
         type: string
+      account_name:
+        type: string
       amount_billed:
         type: number
       amount_paid:

--- a/internal/handlers/billings_test.go
+++ b/internal/handlers/billings_test.go
@@ -315,6 +315,7 @@ func TestBillingHandler_GetOne(t *testing.T) {
 		mockSvc.On("GetByID", mock.Anything, "billing-123", "user_123").Return(&models.AccountBilling{
 			ID:           "billing-123",
 			AccountID:    "account-123",
+			AccountName:  "Main account",
 			Period:       202603,
 			AmountBilled: 15000,
 		}, nil)
@@ -329,6 +330,11 @@ func TestBillingHandler_GetOne(t *testing.T) {
 		handler.GetOne(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
+		var response map[string]interface{}
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.NoError(t, err)
+		data := response["data"].(map[string]interface{})
+		assert.Equal(t, "Main account", data["account_name"])
 	})
 
 	t.Run("error - not found", func(t *testing.T) {
@@ -345,7 +351,6 @@ func TestBillingHandler_GetOne(t *testing.T) {
 
 		assert.Equal(t, http.StatusNotFound, w.Code)
 	})
-
 
 }
 

--- a/internal/models/billing.go
+++ b/internal/models/billing.go
@@ -7,6 +7,7 @@ import "time"
 type AccountBilling struct {
 	ID           string     `json:"id"`
 	AccountID    string     `json:"account_id"`
+	AccountName  string     `json:"account_name,omitempty"`
 	Period       int        `json:"period"`
 	AmountBilled float64    `json:"amount_billed"`
 	AmountPaid   float64    `json:"amount_paid"`
@@ -25,9 +26,9 @@ type CreateBillingRequest struct {
 	Period       int        `json:"period"`
 	AmountBilled float64    `json:"amount_billed"`
 	AmountPaid   *float64   `json:"amount_paid,omitempty"`  // opcional; si >= amount_billed se marca como pagada
-	IsPaid       *bool      `json:"is_paid,omitempty"`       // opcional; fuerza estado pagado
-	PaidAt       *time.Time `json:"paid_at,omitempty"`       // opcional; fecha de pago
-	CarriedFrom  *string    `json:"carried_from,omitempty"`  // UUID de factura impaga anterior (carry-over manual)
+	IsPaid       *bool      `json:"is_paid,omitempty"`      // opcional; fuerza estado pagado
+	PaidAt       *time.Time `json:"paid_at,omitempty"`      // opcional; fecha de pago
+	CarriedFrom  *string    `json:"carried_from,omitempty"` // UUID de factura impaga anterior (carry-over manual)
 }
 
 type UpdateBillingRequest struct {

--- a/internal/models/billing_test.go
+++ b/internal/models/billing_test.go
@@ -13,6 +13,7 @@ func TestAccountBilling_Struct(t *testing.T) {
 	billing := AccountBilling{
 		ID:           "billing-123",
 		AccountID:    "account-123",
+		AccountName:  "Main account",
 		Period:       202603,
 		AmountBilled: 15000.00,
 		AmountPaid:   15000.00,
@@ -22,6 +23,7 @@ func TestAccountBilling_Struct(t *testing.T) {
 
 	assert.Equal(t, "billing-123", billing.ID)
 	assert.Equal(t, "account-123", billing.AccountID)
+	assert.Equal(t, "Main account", billing.AccountName)
 	assert.Equal(t, 202603, billing.Period)
 	assert.Equal(t, 15000.00, billing.AmountBilled)
 	assert.Equal(t, 15000.00, billing.AmountPaid)

--- a/internal/repository/billing_repo.go
+++ b/internal/repository/billing_repo.go
@@ -79,13 +79,16 @@ func (r *billingRepo) CreateCarryOver(ctx context.Context, accountID string, per
 
 func (r *billingRepo) GetByID(ctx context.Context, id, authUserID string) (*models.AccountBilling, error) {
 	var b models.AccountBilling
-	err := scanBilling(r.db.QueryRow(ctx, `
-		SELECT `+billingColsAB+`
+	err := r.db.QueryRow(ctx, `
+		SELECT `+billingColsAB+`, a.name
 		FROM homepay.account_billings ab
 		JOIN homepay.accounts a ON a.id = ab.account_id
 		JOIN homepay.companies c ON c.id = a.company_id
-		WHERE ab.id = $1 AND c.auth_user_id = $2 AND ab.deleted_at IS NULL
-	`, id, authUserID), &b)
+		WHERE ab.id = $1 AND c.auth_user_id = $2 AND ab.deleted_at IS NULL AND a.deleted_at IS NULL AND c.deleted_at IS NULL
+	`, id, authUserID).Scan(
+		&b.ID, &b.AccountID, &b.Period, &b.AmountBilled, &b.AmountPaid,
+		&b.IsPaid, &b.PaidAt, &b.CarriedFrom, &b.CreatedAt, &b.DeletedAt, &b.AccountName,
+	)
 	if err == pgx.ErrNoRows {
 		return nil, nil
 	}

--- a/internal/repository/billing_repo_integration_test.go
+++ b/internal/repository/billing_repo_integration_test.go
@@ -298,6 +298,7 @@ func TestBillingRepo_GetByID_Integration(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, billing)
 		assert.Equal(t, createdBilling.ID, billing.ID)
+		assert.Equal(t, "Test Account", billing.AccountName)
 		assert.Equal(t, 202603, billing.Period)
 	})
 

--- a/internal/repository/billing_repo_test.go
+++ b/internal/repository/billing_repo_test.go
@@ -406,14 +406,16 @@ func TestBillingRepo_CreateCarryOver_Query(t *testing.T) {
 
 func TestBillingRepo_GetByID_Query(t *testing.T) {
 	// Test SELECT with JOIN
-	query := `SELECT ab.id, ab.account_id, ab.period, ab.amount_billed, ab.amount_paid, ab.is_paid, ab.paid_at, ab.carried_from, ab.created_at, ab.deleted_at
+	query := `SELECT ab.id, ab.account_id, ab.period, ab.amount_billed, ab.amount_paid, ab.is_paid, ab.paid_at, ab.carried_from, ab.created_at, ab.deleted_at, a.name
 		FROM homepay.account_billings ab
 		JOIN homepay.accounts a ON a.id = ab.account_id
 		JOIN homepay.companies c ON c.id = a.company_id
-		WHERE ab.id = $1 AND c.auth_user_id = $2 AND ab.deleted_at IS NULL`
+		WHERE ab.id = $1 AND c.auth_user_id = $2 AND ab.deleted_at IS NULL AND a.deleted_at IS NULL AND c.deleted_at IS NULL`
 
 	assert.Contains(t, query, "JOIN homepay.accounts")
 	assert.Contains(t, query, "JOIN homepay.companies")
+	assert.Contains(t, query, "a.name")
+	assert.Contains(t, query, "c.auth_user_id = $2")
 }
 
 func TestBillingRepo_GetByAccountAndPeriod_Query(t *testing.T) {


### PR DESCRIPTION
## Summary
- Include `account_name` in `GET /billings/{id}` detail responses.
- Populate the value from the related account while preserving user authorization boundaries.
- Update Swagger docs and focused repository/handler tests.

Closes #33

## Test plan
- [x] `go test ./internal/handlers -run TestBillingHandler_GetOne -count=1`
- [x] `go test ./internal/repository -run 'TestBillingRepo_GetByID_Integration|TestBillingRepo_GetAll_CrossUserAuthIsolation' -count=1`
- [x] `go test ./...`

## Review notes
- Fresh R1 risk review: no findings.
- Fresh R3 reliability review: pass, no blocking findings.